### PR TITLE
Update createFileImportJob colab to reflect new validation result fields

### DIFF
--- a/use-cases/Create_File_Import_Job_Use_Case.ipynb
+++ b/use-cases/Create_File_Import_Job_Use_Case.ipynb
@@ -132,7 +132,13 @@
     "            dryRun: true,\n",
     "          }\n",
     "        ) {\n",
-    "          validationResult { validationStatus, errorFilePath, error }\n",
+    "          validationResult { \n",
+    "            validationStatus \n",
+    "            filePath \n",
+    "            error {\n",
+    "              message\n",
+    "            } \n",
+    "          }\n",
     "        }\n",
     "     }\n",
     "    \"\"\"\n",
@@ -154,7 +160,7 @@
     "\n",
     "# print the error if the dry run fails\n",
     "if (result[\"createFileImportJob\"][\"validationResult\"][\"validationStatus\"] == \"fail\"):\n",
-    "  print(f'{result[\"createFileImportJob\"][\"validationResult\"][\"errorFilePath\"]}: {result[\"createFileImportJob\"][\"validationResult\"][\"error\"]}')"
+    "  print(f'{result[\"createFileImportJob\"][\"validationResult\"][\"filePath\"]}: {result[\"createFileImportJob\"][\"validationResult\"][\"error\"][\"message\"]}')"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- the validationResult object that's returned when dry running a file import job has changed. The colab needs to be adjusted to reflect this change
  - errorFilePath -> filePath
  - error (string type) -> error (FileError type which contains the message string along with the error code and row)
## Preview
![image](https://user-images.githubusercontent.com/78773152/202609902-b240c10e-afa2-4c37-b5e8-d6b23bbd7510.png)